### PR TITLE
Fix chrome block breaker on iphone

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,11 @@ body {
     width: 100%;
     height: 100%;
     touch-action: none;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .container {
@@ -28,6 +33,7 @@ body {
     height: 100%;
     overflow: auto;
     -webkit-overflow-scrolling: touch;
+    touch-action: pan-y;
 }
 
 h1 {
@@ -96,6 +102,7 @@ h1 {
     backdrop-filter: blur(10px);
     border: 2px solid rgba(255, 255, 255, 0.2);
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    touch-action: none;
 }
 
 .game-header {
@@ -159,7 +166,11 @@ h1 {
     touch-action: none;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
     user-select: none;
+    -webkit-tap-highlight-color: transparent;
+    cursor: pointer;
 }
 
 .game-instructions {
@@ -271,6 +282,12 @@ h1 {
     
     .game-over-buttons {
         flex-direction: column;
+    }
+    
+    /* iOS Safari specific fixes */
+    .game-screen {
+        -webkit-transform: translateZ(0);
+        transform: translateZ(0);
     }
 }
 


### PR DESCRIPTION
Implement tap-and-drag paddle controls and fix iOS Chrome compatibility for the block breaker game.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2d13684-8b80-4e6c-96c7-81f7bc0425d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2d13684-8b80-4e6c-96c7-81f7bc0425d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

