### PR TITLE
Fix breakout link on index html

### DIFF
--- a/games.js
+++ b/games.js
@@ -608,12 +608,14 @@ function startGame(gameType) {
         console.error('GameManager not initialized yet');
         return;
     }
+    
     gameManager.showScreen('gameScreen');
     
     switch (gameType) {
         case 'breakout':
             gameManager.currentGame = new BreakoutGame(gameManager);
             document.getElementById('gameTitle').textContent = 'ブロック崩し';
+            gameManager.currentGame.startGame();
             break;
         default:
             alert('このゲームはまだ準備中です！');
@@ -653,6 +655,7 @@ function restartGame() {
         gameManager.currentGame.initializeGame();
         gameManager.showScreen('gameScreen');
         gameManager.gameState = 'playing';
+        gameManager.currentGame.startGame();
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <div id="gameMenu" class="game-menu">
             <h2>ゲームを選んでください</h2>
             <div class="game-buttons">
-                <button class="game-btn" onclick="startGame('breakout')">
+                <button class="game-btn" onclick="startGame('breakout')" ontouchstart="">
                     🧱 ブロック崩し
                 </button>
                 <button class="game-btn" onclick="startGame('snake')" disabled>


### PR DESCRIPTION
Call `startGame()` on the game instance and add `ontouchstart` to ensure the Breakout game starts correctly after selection.

---
<a href="https://cursor.com/background-agent?bcId=bc-53b278e0-7bf9-49c9-903b-850929bd1930">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-53b278e0-7bf9-49c9-903b-850929bd1930">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

