### PR TITLE
Fix unresponsive program screen

### DIFF
--- a/games.js
+++ b/games.js
@@ -189,6 +189,7 @@ class BreakoutGame {
         this.touchX = null;
         this.targetPaddleX = null;
         this.paddleVelocity = 0;
+        this.autoStart = false; // 自動開始フラグ
         
         this.initializeGame();
     }
@@ -333,12 +334,18 @@ class BreakoutGame {
     }
 
     startGame() {
+        console.log('BreakoutGame.startGame() called');
         this.gameRunning = true;
+        // ゲーム開始時にボールをリセット
+        this.resetBall();
         this.gameLoop();
     }
 
     gameLoop() {
-        if (!this.gameRunning) return;
+        if (!this.gameRunning) {
+            console.log('gameLoop stopped - gameRunning is false');
+            return;
+        }
         
         this.update();
         this.draw();
@@ -496,8 +503,8 @@ class BreakoutGame {
         // ブロックを描画
         this.drawBlocks();
         
-        // ゲーム開始前のメッセージ
-        if (!this.gameRunning) {
+        // ゲーム開始前のメッセージ（autoStartの場合は表示しない）
+        if (!this.gameRunning && !this.autoStart) {
             this.drawStartMessage();
         }
     }
@@ -615,7 +622,13 @@ function startGame(gameType) {
         case 'breakout':
             gameManager.currentGame = new BreakoutGame(gameManager);
             document.getElementById('gameTitle').textContent = 'ブロック崩し';
-            gameManager.currentGame.startGame();
+            // 自動的にゲームを開始（開始メッセージを表示しない）
+            gameManager.currentGame.autoStart = true;
+            setTimeout(() => {
+                if (gameManager.currentGame) {
+                    gameManager.currentGame.startGame();
+                }
+            }, 100);
             break;
         default:
             alert('このゲームはまだ準備中です！');


### PR DESCRIPTION
Enable automatic game start for Breakout to fix the issue where the game displayed but did not move.

The game was stuck on a "start message" overlay because `gameRunning` was `false` and the `gameLoop` was not executing. This change introduces an `autoStart` flag and ensures `startGame()` is called after initialization, allowing the game to begin immediately upon selection.

---
<a href="https://cursor.com/background-agent?bcId=bc-6306a86d-d608-4328-8719-9bca960511a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6306a86d-d608-4328-8719-9bca960511a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

