### PR TITLE
横スクロールシューティングゲームの改善とバグ修正

### DIFF
--- a/shmup-zero/index.html
+++ b/shmup-zero/index.html
@@ -45,20 +45,21 @@
         </div>
       </div>
 
-      <!-- モバイル発射ボタン（右下固定） -->
-      <button id="fireBtn" class="btn fire-btn" aria-label="発射">🚀 発射</button>
+        <!-- モバイル発射ボタン（右下固定） -->
+        <button id="fireBtn" class="btn fire-btn" aria-label="発射">🚀 発射</button>
 
-      <div id="overlay" class="overlay hidden">
-        <div class="panel">
-          <h1 class="title">Shmup Zero</h1>
-          <p class="subtitle">横向きでプレイ推奨。ドラッグで移動 / 右下の発射ボタン長押しで射撃（PC: 矢印/WASD + スペース）</p>
-          <div class="controls">
-            <button id="startBtn" class="btn primary">ゲーム開始</button>
-            <button id="restartBtn" class="btn hidden">もう一度</button>
+        <div id="overlay" class="overlay hidden">
+          <div class="panel">
+            <h1 class="title">Shmup Zero</h1>
+            <p class="subtitle">横向きでプレイ推奨。ドラッグで移動 / 右下の発射ボタン長押しで射撃（PC: 矢印/WASD + スペース）</p>
+            <div class="controls">
+              <button id="startBtn" class="btn primary">ゲーム開始</button>
+              <button id="restartBtn" class="btn hidden">もう一度</button>
+              <button id="resumeStageBtn" class="btn hidden">同じステージから再開</button>
+            </div>
+            <div id="finalStats" class="final-stats hidden"></div>
           </div>
-          <div id="finalStats" class="final-stats hidden"></div>
         </div>
-      </div>
 
       <!-- ステージクリア時モーダル -->
       <div id="stageModal" class="overlay hidden">


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-e94a6f83-5d69-4d6b-a093-4fa2d71120d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e94a6f83-5d69-4d6b-a093-4fa2d71120d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds stage resume flow, a speed-boost item, smoother drag movement, big boss HP buff, and lowers max shot lines while turning off auto-fire by default.
> 
> - **Gameplay/Systems**:
>   - Add stage resume flow (`resumeStageBtn`) with continue stage/score and start-at-stage support in `startGame/resetGame`.
>   - Disable `AUTO_FIRE` by default; ensure firing starts instantly on press.
> - **Items**:
>   - Introduce speed-boost item (`speedItems`) with visuals (`drawSpeedItem`), drops, updates, and pickup effects (1.6x speed for 6s).
>   - Cap power shot lines to `MAX_SHOT_LINES = 2` and align power/companion upgrades accordingly.
> - **Controls/Movement**:
>   - Change drag handling to target-based smooth movement (`targetX/targetY`) with speed-boost-aware velocity.
>   - Add `touchcancel` handler for fire button.
> - **UI**:
>   - Add "同じステージから再開" button and show on game over; update pause button on start; keep stats display safe-guarded.
> - **Balance**:
>   - Multiply boss HP by 5 across stages; adjust boss HUD updates.
>   - Tint companion bullets differently from player bullets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36e364316d092f5f85a81a87b266b59517852e9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->