### PR TITLE
Implement horizontal scroll settings menu

### DIFF
--- a/shmup-zero/index.html
+++ b/shmup-zero/index.html
@@ -48,6 +48,54 @@
         <!-- モバイル発射ボタン（右下固定） -->
         <button id="fireBtn" class="btn fire-btn" aria-label="発射">🚀 発射</button>
 
+          <!-- ポーズ設定オーバーレイ -->
+          <div id="pauseSettings" class="overlay hidden" role="dialog" aria-modal="true" aria-labelledby="pauseSettingsTitle">
+            <div class="panel settings-panel">
+              <h2 id="pauseSettingsTitle" class="title">ポーズ設定</h2>
+              <form id="settingsForm" class="settings-form">
+                <fieldset class="settings-group">
+                  <legend>操作タイプ</legend>
+                  <div class="settings-options settings-modes">
+                    <label class="settings-option" for="controlRelative">
+                      <input type="radio" name="controlMode" id="controlRelative" value="relative" />
+                      <span>バーチャルスティック（現行の操作）</span>
+                    </label>
+                    <label class="settings-option" for="controlFollow">
+                      <input type="radio" name="controlMode" id="controlFollow" value="follow" />
+                      <span>指に合わせて機体が追従（以前の操作）</span>
+                    </label>
+                  </div>
+                </fieldset>
+
+                <fieldset class="settings-group">
+                  <legend>アイテム獲得状態</legend>
+                  <div class="settings-options settings-items">
+                    <label class="settings-option" for="itemAttack">
+                      <input type="checkbox" id="itemAttack" />
+                      <span>攻撃強化（パワーアップ）</span>
+                    </label>
+                    <label class="settings-option" for="itemCompanion">
+                      <input type="checkbox" id="itemCompanion" />
+                      <span>子機サポート</span>
+                    </label>
+                    <label class="settings-option" for="itemBarrier">
+                      <input type="checkbox" id="itemBarrier" />
+                      <span>バリア（シールド）</span>
+                    </label>
+                    <label class="settings-option" for="itemSpeed">
+                      <input type="checkbox" id="itemSpeed" />
+                      <span>スピードアップ</span>
+                    </label>
+                  </div>
+                </fieldset>
+              </form>
+              <div class="controls settings-controls">
+                <button id="settingsApplyBtn" type="button" class="btn primary">設定を反映して再開</button>
+                <button id="settingsResumeBtn" type="button" class="btn">変更せずに再開</button>
+              </div>
+            </div>
+          </div>
+
         <div id="overlay" class="overlay hidden">
           <div class="panel">
             <h1 class="title">Shmup Zero</h1>

--- a/shmup-zero/style.css
+++ b/shmup-zero/style.css
@@ -49,6 +49,16 @@ body {
 .overlay#stageModal { position: absolute; }
 .overlay.hidden { display: none; }
 .panel { background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.15); backdrop-filter: blur(6px); border-radius: 16px; padding: 24px; max-width: 600px; width: min(90vw, 560px); text-align: center; }
+.settings-panel { text-align: left; }
+.settings-form { display: flex; flex-direction: column; gap: 20px; margin: 20px 0; }
+.settings-group { border: 1px solid rgba(255,255,255,0.18); border-radius: 12px; padding: 16px; }
+.settings-group legend { font-weight: 700; padding: 0 8px; }
+.settings-options { display: grid; gap: 12px; }
+.settings-options.settings-modes { grid-template-columns: 1fr; }
+.settings-options.settings-items { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+.settings-option { display: flex; align-items: flex-start; gap: 10px; line-height: 1.5; font-size: 15px; }
+.settings-option input { margin-top: 3px; accent-color: var(--accent); }
+.settings-controls { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; margin-top: 8px; }
 .title { margin: 0 0 8px; letter-spacing: 1px; }
 .subtitle { margin: 0 0 16px; opacity: 0.85; }
 .final-stats { margin-top: 12px; }


### PR DESCRIPTION
Add a pause settings screen to allow users to customize control mode and item acquisition status.

The user specifically requested the ability to change control modes (current virtual stick vs. previous finger-follow) and to freely set the acquired status of attack, companion, barrier, and speed items via a pause menu. This PR implements that functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-9caa0491-aa80-4014-989b-758b478288d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9caa0491-aa80-4014-989b-758b478288d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a pause settings screen to switch between virtual stick and follow-touch controls and toggle item states, persisting choices and applying them in-game.
> 
> - **Gameplay/Controls**:
>   - **Control modes**: Implement `FollowTouch` alongside existing relative stick; integrate follow pointer handling (`pointerdown/move/up/cancel`) and movement logic; conditionally render virtual stick overlay.
>   - **Settings application**: Apply item states via `setAttackState`, `setCompanionState`, `setBarrierState`, `setSpeedState`; hook into game reset/start, pause/resume, game over, and stage clear.
> - **State/Persistence**:
>   - Load/save user settings in `localStorage` (`shmupZeroSettings`); `createDefaultSettings`, `loadUserSettings`, `saveUserSettings`; `applyItemSettingsFromUser` and `setControlMode`.
> - **UI**:
>   - Add pause settings overlay `#pauseSettings` with form `#settingsForm` (radio: `controlRelative`/`controlFollow`; checkboxes: `itemAttack`, `itemCompanion`, `itemBarrier`, `itemSpeed`) and action buttons (`#settingsApplyBtn`, `#settingsResumeBtn`).
>   - Wire up form population (`populateSettingsFormFromGame`), updates (`updateSettingsFromForm`), show/hide (`showPauseSettings`/`hidePauseSettings`), and styles in `style.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acdcc24bb3c34b5151f6c009e38e3bc401e4ab74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->